### PR TITLE
Fix redirect handling in download utils + add connection timeouts

### DIFF
--- a/common/src/main/java/dev/oxydien/simpleModSync/io/FileOperations.java
+++ b/common/src/main/java/dev/oxydien/simpleModSync/io/FileOperations.java
@@ -42,10 +42,13 @@ public class FileOperations {
         int maxRedirects = 10;
         String currentUri = uriString;
         URLConnection connection = null;
+        boolean resolved = false;
 
         for (int i = 0; i < maxRedirects; i++) {
             URL url = new URI(currentUri).toURL();
             connection = url.openConnection();
+            connection.setConnectTimeout(10_000);
+            connection.setReadTimeout(30_000);
 
             if (connection instanceof HttpURLConnection httpURLConnection) {
                 httpURLConnection.setRequestMethod("GET");
@@ -67,10 +70,11 @@ public class FileOperations {
                     continue;
                 }
             }
+            resolved = true;
             break; // non-HTTP connection or non-redirect response — proceed to download
         }
 
-        if (connection == null) {
+        if (!resolved) {
             throw new IOException("Too many redirects while fetching: " + uriString);
         }
 

--- a/common/src/main/java/dev/oxydien/simpleModSync/io/FileOperations.java
+++ b/common/src/main/java/dev/oxydien/simpleModSync/io/FileOperations.java
@@ -9,7 +9,6 @@ import java.io.OutputStream;
 import java.net.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 public class FileOperations {
     private final SyncSchema syncSchema;
@@ -38,16 +37,45 @@ public class FileOperations {
     }
 
     public void downloadFileWithProgress(String uriString, Path outputPath, ProgressCallback callback) throws IOException, URISyntaxException {
-        URL url = new URI(uriString).toURL();
-        URLConnection connection = url.openConnection();
+        // Manually follow redirects so cross-protocol redirects (e.g. http -> https
+        // from URL shorteners) are handled correctly.
+        int maxRedirects = 10;
+        String currentUri = uriString;
+        URLConnection connection = null;
 
-        if  (connection instanceof HttpURLConnection httpURLConnection) {
-            httpURLConnection.setRequestMethod("GET");
+        for (int i = 0; i < maxRedirects; i++) {
+            URL url = new URI(currentUri).toURL();
+            connection = url.openConnection();
+
+            if (connection instanceof HttpURLConnection httpURLConnection) {
+                httpURLConnection.setRequestMethod("GET");
+                httpURLConnection.setRequestProperty("User-Agent", "Mozilla/5.0 (compatible; SimpleModSync)");
+                httpURLConnection.setInstanceFollowRedirects(false);
+
+                int responseCode = httpURLConnection.getResponseCode();
+                if (responseCode >= 300 && responseCode < 400) {
+                    String location = httpURLConnection.getHeaderField("Location");
+                    httpURLConnection.disconnect();
+                    if (location == null) {
+                        throw new IOException("Redirect (HTTP " + responseCode + ") with no Location header");
+                    }
+                    if (!location.startsWith("http://") && !location.startsWith("https://")) {
+                        URL base = new URI(currentUri).toURL();
+                        location = new URL(base, location).toString();
+                    }
+                    currentUri = location;
+                    continue;
+                }
+            }
+            break; // non-HTTP connection or non-redirect response — proceed to download
+        }
+
+        if (connection == null) {
+            throw new IOException("Too many redirects while fetching: " + uriString);
         }
 
         long fileSize = connection.getContentLengthLong();
         InputStream inputStream = connection.getInputStream();
-
         OutputStream outputStream = Files.newOutputStream(outputPath);
 
         byte[] buffer = new byte[4096];

--- a/common/src/main/java/dev/oxydien/simpleModSync/utils/DownloadUtils.java
+++ b/common/src/main/java/dev/oxydien/simpleModSync/utils/DownloadUtils.java
@@ -18,6 +18,8 @@ public class DownloadUtils {
         for (int i = 0; i < maxRedirects; i++) {
             URL url = new URI(currentUri).toURL();
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setConnectTimeout(10_000);
+            connection.setReadTimeout(30_000);
             connection.setRequestMethod("GET");
             // setting the User-Agent header for CDNs that care about bots
             connection.setRequestProperty("User-Agent", "Mozilla/5.0 (compatible; SimpleModSync)");

--- a/common/src/main/java/dev/oxydien/simpleModSync/utils/DownloadUtils.java
+++ b/common/src/main/java/dev/oxydien/simpleModSync/utils/DownloadUtils.java
@@ -12,18 +12,44 @@ import java.util.stream.Collectors;
 
 public class DownloadUtils {
     public static String downloadString(String uriString) throws IOException, URISyntaxException {
-        URL url = new URI(uriString).toURL();
-        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-        connection.setRequestMethod("GET");
+        int maxRedirects = 10;
+        String currentUri = uriString;
 
-        InputStream inputStream = connection.getInputStream();
-        BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
-        String jsonString = reader.lines().collect(Collectors.joining("\n"));
+        for (int i = 0; i < maxRedirects; i++) {
+            URL url = new URI(currentUri).toURL();
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("GET");
+            // setting the User-Agent header for CDNs that care about bots
+            connection.setRequestProperty("User-Agent", "Mozilla/5.0 (compatible; SimpleModSync)");
+            connection.setInstanceFollowRedirects(false); // we handle redirects manually
 
-        reader.close();
-        inputStream.close();
-        connection.disconnect();
+            int responseCode = connection.getResponseCode();
 
-        return jsonString;
+            if (responseCode >= 300 && responseCode < 400) {
+                String location = connection.getHeaderField("Location");
+                connection.disconnect();
+                if (location == null) {
+                    throw new IOException("Redirect (HTTP " + responseCode + ") with no Location header");
+                }
+                // Handle relative redirect URLs
+                if (!location.startsWith("http://") && !location.startsWith("https://")) {
+                    location = new URI(currentUri).resolve(location).toString();
+                }
+                currentUri = location;
+                continue;
+            }
+
+            InputStream inputStream = connection.getInputStream();
+            BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+            String jsonString = reader.lines().collect(Collectors.joining("\n"));
+
+            reader.close();
+            inputStream.close();
+            connection.disconnect();
+
+            return jsonString;
+        }
+
+        throw new IOException("Too many redirects while fetching: " + uriString);
     }
 }


### PR DESCRIPTION
Java's default HttpURLConnection redirect handling silently fails on cross-protocol redirects (http → https), which several mod host/CDN URLs rely on (e.g. URL shorteners, some mirror redirects). This caused downloads to fail even though the URL itself was valid.

Changes:
DownloadUtils.downloadString and FileOperations.downloadFileWithProgress now manually follow redirects (up to 10 hops) instead of relying on HttpURLConnection's built-in handling, so http→https and relative Location headers both resolve correctly.
Added a User-Agent header, since some CDNs reject requests with no/default Java user agent.
Added connect (10s) and read (30s) timeouts so a slow or dead mirror fails with an error instead of hanging indefinitely.
Fixed a bug in FileOperations where exceeding the redirect limit didn't throw the intended "too many redirects" error — it fell through to a disconnected connection and threw a confusing low-level exception instead.

Testing:
Verified with a standalone test harness (local mock HTTP server, not included in this PR) covering: chained redirects, relative Location headers, missing Location header, redirect loops, file downloads through redirects, and User-Agent propagation — all passing. Also tested against a live redirecting URL.

Note: portions of this fix (redirect-following logic and test harness) were developed with AI assistance (Claude) and reviewed/tested by me before submitting.